### PR TITLE
Some localisation fixed related to data plans

### DIFF
--- a/app/src/main/java/com/drnoob/datamonitor/Common.java
+++ b/app/src/main/java/com/drnoob/datamonitor/Common.java
@@ -399,7 +399,8 @@ public class Common {
     public static String getPlanValidity(int session, Context context) {
         String validity;
         Calendar calendar = Calendar.getInstance();
-        String month, endDate, suffix, end;
+        String month, ordinal, end;
+        int endDate;
         if (session == SESSION_MONTHLY) {
             int planEnd = PreferenceManager.getDefaultSharedPreferences(context)
                     .getInt(DATA_RESET_DATE, 1);
@@ -412,7 +413,7 @@ public class Common {
                 calendar.set(Calendar.MONTH, calendar.get(Calendar.MONTH) + 1);
             }
             month = new SimpleDateFormat("MMMM").format(calendar.getTime());
-            endDate = String.valueOf(planEnd);
+            endDate = planEnd;
         }
         else {
             long planEndDateMillis;
@@ -427,29 +428,30 @@ public class Common {
             }
             calendar.setTimeInMillis(planEndDateMillis);
             month = new SimpleDateFormat("MMMM").format(calendar.getTime());
-            endDate = new SimpleDateFormat("d").format(calendar.getTime());
+            endDate = calendar.get(Calendar.DAY_OF_MONTH);
         }
-        suffix = getDateSuffix(endDate);
-        end = endDate + suffix + " " + month;
+        ordinal = formatOrdinalNumber(endDate);
+        end = ordinal + " " + month;
         validity = end;
         return validity;
     }
 
-    public static String getDateSuffix(String date) {
+    public static String formatOrdinalNumber(int number) {
+        String numberString = String.valueOf(number);
         String suffix;
-        if (date.endsWith("1")) {
+        if (numberString.endsWith("1")) {
             suffix = "st";
         }
-        else if (date.endsWith("2")) {
+        else if (numberString.endsWith("2")) {
             suffix = "nd";
         }
-        else if (date.endsWith("3")) {
+        else if (numberString.endsWith("3")) {
             suffix = "rd";
         }
         else {
             suffix = "th";
         }
-        return suffix;
+        return numberString + suffix;
     }
 
     private static boolean isLiveNetworkServiceRunning(Context context) {

--- a/app/src/main/java/com/drnoob/datamonitor/Common.java
+++ b/app/src/main/java/com/drnoob/datamonitor/Common.java
@@ -396,7 +396,6 @@ public class Common {
         postNotification(context, managerCompat, builder, OTHER_NOTIFICATION_ID);
     }
 
-    @SuppressLint("SimpleDateFormat")
     public static String getPlanValidity(int session, Context context) {
         String validity;
         Calendar calendar = Calendar.getInstance();
@@ -413,7 +412,7 @@ public class Common {
             if (today >= planEnd) {
                 calendar.set(Calendar.MONTH, calendar.get(Calendar.MONTH) + 1);
             }
-            month = new SimpleDateFormat("MMMM").format(calendar.getTime());
+            month = new SimpleDateFormat("MMMM", getCurrentLocale(context)).format(calendar.getTime());
             endDate = planEnd;
         }
         else {
@@ -428,7 +427,7 @@ public class Common {
                 planEndDateMillis = ((Number) planEndIntValue).longValue();
             }
             calendar.setTimeInMillis(planEndDateMillis);
-            month = new SimpleDateFormat("MMMM").format(calendar.getTime());
+            month = new SimpleDateFormat("MMMM", getCurrentLocale(context)).format(calendar.getTime());
             endDate = calendar.get(Calendar.DAY_OF_MONTH);
         }
         ordinal = formatOrdinalNumber(endDate, context);

--- a/app/src/main/java/com/drnoob/datamonitor/Common.java
+++ b/app/src/main/java/com/drnoob/datamonitor/Common.java
@@ -47,6 +47,7 @@ import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.graphics.Typeface;
+import android.icu.text.MessageFormat;
 import android.os.Build;
 import android.provider.Settings;
 import android.text.Spannable;
@@ -430,28 +431,42 @@ public class Common {
             month = new SimpleDateFormat("MMMM").format(calendar.getTime());
             endDate = calendar.get(Calendar.DAY_OF_MONTH);
         }
-        ordinal = formatOrdinalNumber(endDate);
+        ordinal = formatOrdinalNumber(endDate, context);
         end = ordinal + " " + month;
         validity = end;
         return validity;
     }
 
-    public static String formatOrdinalNumber(int number) {
-        String numberString = String.valueOf(number);
-        String suffix;
-        if (numberString.endsWith("1")) {
-            suffix = "st";
+    public static String formatOrdinalNumber(int number, Context context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            final String format = "{0,ordinal}";
+            final Locale locale = getCurrentLocale(context);
+            final MessageFormat formatter = new MessageFormat(format, locale);
+
+            return formatter.format(new Object[] {number});
+        } else {
+            String numberString = String.valueOf(number);
+            String suffix;
+            if (numberString.endsWith("1")) {
+                suffix = "st";
+            } else if (numberString.endsWith("2")) {
+                suffix = "nd";
+            } else if (numberString.endsWith("3")) {
+                suffix = "rd";
+            } else {
+                suffix = "th";
+            }
+            return numberString + suffix;
         }
-        else if (numberString.endsWith("2")) {
-            suffix = "nd";
+    }
+
+    public static Locale getCurrentLocale(Context context) {
+        final Configuration config = context.getResources().getConfiguration();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            return config.getLocales().get(0);
+        } else {
+            return config.locale;
         }
-        else if (numberString.endsWith("3")) {
-            suffix = "rd";
-        }
-        else {
-            suffix = "th";
-        }
-        return numberString + suffix;
     }
 
     private static boolean isLiveNetworkServiceRunning(Context context) {

--- a/app/src/main/java/com/drnoob/datamonitor/ui/fragments/HomeFragment.java
+++ b/app/src/main/java/com/drnoob/datamonitor/ui/fragments/HomeFragment.java
@@ -395,22 +395,21 @@ public class HomeFragment extends Fragment implements View.OnLongClickListener {
     private void updateDataBalance() {
         Long[] mobileData = null;
         int date = preferences.getInt(DATA_RESET_DATE, 1);
-        String planType = requireContext().getString(R.string.label_unknown),
-                planDetailsTitle;
+        String planDetailsTitle = requireContext().getString(R.string.label_plan_details_title_unknown);
         boolean isSmartAllocationEnabled = preferences.getBoolean("smart_data_allocation", false);
 
         try {
             if (preferences.getString(DATA_RESET, "null")
                     .equals(DATA_RESET_MONTHLY)) {
                 mobileData = getDeviceMobileDataUsage(getContext(), SESSION_MONTHLY, date);
-                planType = requireContext().getString(R.string.monthly);
+                planDetailsTitle = requireContext().getString(R.string.label_plan_details_title_monthly);
             } else if (preferences.getString(DATA_RESET, "null")
                     .equals(DATA_RESET_DAILY)) {
                 mobileData = getDeviceMobileDataUsage(getContext(), SESSION_TODAY, 1);
-                planType = requireContext().getString(R.string.daily);
+                planDetailsTitle = requireContext().getString(R.string.label_plan_details_title_daily);
             } else {
                 mobileData = getDeviceMobileDataUsage(getContext(), SESSION_CUSTOM, -1);
-                planType = requireContext().getString(R.string.custom);
+                planDetailsTitle = requireContext().getString(R.string.label_plan_details_title_custom);
             }
 
         } catch (ParseException | RemoteException e) {
@@ -527,7 +526,6 @@ public class HomeFragment extends Fragment implements View.OnLongClickListener {
 
             mDataRemaining.setVisibility(View.GONE);
             mPlanDetailsView.setVisibility(View.VISIBLE);
-            planDetailsTitle = requireContext().getString(R.string.label_plan_details_title, planType);
             mPlanDetailsTitle.setText(planDetailsTitle);
         } else {
             // No data plan is set. Hide mDataRemaining view.

--- a/app/src/main/java/com/drnoob/datamonitor/ui/fragments/HomeFragment.java
+++ b/app/src/main/java/com/drnoob/datamonitor/ui/fragments/HomeFragment.java
@@ -20,6 +20,7 @@
 package com.drnoob.datamonitor.ui.fragments;
 
 import static com.drnoob.datamonitor.Common.dismissOnClick;
+import static com.drnoob.datamonitor.Common.getDateSuffix;
 import static com.drnoob.datamonitor.Common.setDataPlanNotification;
 import static com.drnoob.datamonitor.Common.setRefreshAlarm;
 import static com.drnoob.datamonitor.core.Values.DAILY_DATA_HOME_ACTION;
@@ -600,20 +601,6 @@ public class HomeFragment extends Fragment implements View.OnLongClickListener {
         String remaining = requireContext().getString(R.string.label_days_remaining, Integer.toString(daysRemaining));
         validity = requireContext().getString(R.string.label_plan_validity, end, remaining);
         return validity;
-    }
-
-    private String getDateSuffix(String date) {
-        String suffix;
-        if (date.endsWith("1")) {
-            suffix = "st";
-        } else if (date.endsWith("2")) {
-            suffix = "nd";
-        } else if (date.endsWith("3")) {
-            suffix = "rd";
-        } else {
-            suffix = "th";
-        }
-        return suffix;
     }
 
     @Override

--- a/app/src/main/java/com/drnoob/datamonitor/ui/fragments/HomeFragment.java
+++ b/app/src/main/java/com/drnoob/datamonitor/ui/fragments/HomeFragment.java
@@ -20,7 +20,7 @@
 package com.drnoob.datamonitor.ui.fragments;
 
 import static com.drnoob.datamonitor.Common.dismissOnClick;
-import static com.drnoob.datamonitor.Common.getDateSuffix;
+import static com.drnoob.datamonitor.Common.formatOrdinalNumber;
 import static com.drnoob.datamonitor.Common.setDataPlanNotification;
 import static com.drnoob.datamonitor.Common.setRefreshAlarm;
 import static com.drnoob.datamonitor.core.Values.DAILY_DATA_HOME_ACTION;
@@ -546,7 +546,8 @@ public class HomeFragment extends Fragment implements View.OnLongClickListener {
     private String getPlanValidity(int session) {
         String validity;
         Calendar calendar = Calendar.getInstance();
-        String month, endDate, suffix, end;
+        String month, ordinal, end;
+        int endDate;
         int daysRemaining;
         if (session == SESSION_MONTHLY) {
             int planReset = preferences.getInt(DATA_RESET_DATE, 1);
@@ -561,7 +562,7 @@ public class HomeFragment extends Fragment implements View.OnLongClickListener {
                 daysRemaining = planReset - today;
             }
             month = new SimpleDateFormat("MMMM").format(calendar.getTime());
-            endDate = String.valueOf(planReset);
+            endDate = planReset;
         }
         else {
             calendar.set(Calendar.HOUR_OF_DAY, 0);
@@ -585,7 +586,7 @@ public class HomeFragment extends Fragment implements View.OnLongClickListener {
             calendar.set(Calendar.MINUTE, planEndMin);
 
             month = new SimpleDateFormat("MMMM").format(calendar.getTime());
-            endDate = new SimpleDateFormat("d").format(calendar.getTime());
+            endDate = calendar.get(Calendar.DAY_OF_MONTH);
 
             long currentTimeMillis = System.currentTimeMillis();
             long endTimeMillis = calendar.getTimeInMillis();
@@ -593,8 +594,8 @@ public class HomeFragment extends Fragment implements View.OnLongClickListener {
             long remainingMillis = endTimeMillis - currentTimeMillis;
             daysRemaining = (int) Math.round((remainingMillis / (24 * 60 * 60 * 1000.0)));
         }
-        suffix = getDateSuffix(endDate);
-        end = endDate + suffix + " " + month;
+        ordinal = formatOrdinalNumber(endDate);
+        end = ordinal + " " + month;
         if (daysRemaining < 0) {
             daysRemaining = 0;
         }

--- a/app/src/main/java/com/drnoob/datamonitor/ui/fragments/HomeFragment.java
+++ b/app/src/main/java/com/drnoob/datamonitor/ui/fragments/HomeFragment.java
@@ -529,18 +529,6 @@ public class HomeFragment extends Fragment implements View.OnLongClickListener {
             mPlanDetailsView.setVisibility(View.VISIBLE);
             planDetailsTitle = requireContext().getString(R.string.label_plan_details_title, planType);
             mPlanDetailsTitle.setText(planDetailsTitle);
-
-
-//            if (shouldShowDetailsView) {
-//                mDataRemaining.setVisibility(View.GONE);
-//                mPlanDetailsView.setVisibility(View.VISIBLE);
-//                planDetailsTitle = requireContext().getString(R.string.label_plan_details_title, planType);
-//                mPlanDetailsTitle.setText(planDetailsTitle);
-//            }
-//            else {
-//                mDataRemaining.setVisibility(View.VISIBLE);
-//                mPlanDetailsView.setVisibility(View.GONE);
-//            }
         } else {
             // No data plan is set. Hide mDataRemaining view.
             mDataRemaining.setVisibility(View.GONE);

--- a/app/src/main/java/com/drnoob/datamonitor/ui/fragments/HomeFragment.java
+++ b/app/src/main/java/com/drnoob/datamonitor/ui/fragments/HomeFragment.java
@@ -594,7 +594,7 @@ public class HomeFragment extends Fragment implements View.OnLongClickListener {
             long remainingMillis = endTimeMillis - currentTimeMillis;
             daysRemaining = (int) Math.round((remainingMillis / (24 * 60 * 60 * 1000.0)));
         }
-        ordinal = formatOrdinalNumber(endDate);
+        ordinal = formatOrdinalNumber(endDate, requireContext());
         end = ordinal + " " + month;
         if (daysRemaining < 0) {
             daysRemaining = 0;

--- a/app/src/main/java/com/drnoob/datamonitor/ui/fragments/HomeFragment.java
+++ b/app/src/main/java/com/drnoob/datamonitor/ui/fragments/HomeFragment.java
@@ -21,6 +21,7 @@ package com.drnoob.datamonitor.ui.fragments;
 
 import static com.drnoob.datamonitor.Common.dismissOnClick;
 import static com.drnoob.datamonitor.Common.formatOrdinalNumber;
+import static com.drnoob.datamonitor.Common.getCurrentLocale;
 import static com.drnoob.datamonitor.Common.setDataPlanNotification;
 import static com.drnoob.datamonitor.Common.setRefreshAlarm;
 import static com.drnoob.datamonitor.core.Values.DAILY_DATA_HOME_ACTION;
@@ -542,7 +543,7 @@ public class HomeFragment extends Fragment implements View.OnLongClickListener {
      *
      * @return Plan reset date and the number of days remaining as a formatted string.
      */
-    @SuppressLint({"StringFormatMatches", "SimpleDateFormat"})
+    @SuppressLint("StringFormatMatches")
     private String getPlanValidity(int session) {
         String validity;
         Calendar calendar = Calendar.getInstance();
@@ -561,7 +562,7 @@ public class HomeFragment extends Fragment implements View.OnLongClickListener {
             else {
                 daysRemaining = planReset - today;
             }
-            month = new SimpleDateFormat("MMMM").format(calendar.getTime());
+            month = new SimpleDateFormat("MMMM", getCurrentLocale(requireContext())).format(calendar.getTime());
             endDate = planReset;
         }
         else {
@@ -585,7 +586,7 @@ public class HomeFragment extends Fragment implements View.OnLongClickListener {
             calendar.set(Calendar.HOUR, planEndHour);
             calendar.set(Calendar.MINUTE, planEndMin);
 
-            month = new SimpleDateFormat("MMMM").format(calendar.getTime());
+            month = new SimpleDateFormat("MMMM", getCurrentLocale(requireContext())).format(calendar.getTime());
             endDate = calendar.get(Calendar.DAY_OF_MONTH);
 
             long currentTimeMillis = System.currentTimeMillis();

--- a/app/src/main/java/com/drnoob/datamonitor/ui/fragments/SetupFragment.java
+++ b/app/src/main/java/com/drnoob/datamonitor/ui/fragments/SetupFragment.java
@@ -21,7 +21,7 @@ package com.drnoob.datamonitor.ui.fragments;
 
 import static com.drnoob.datamonitor.Common.cancelDataPlanNotification;
 import static com.drnoob.datamonitor.Common.dismissOnClick;
-import static com.drnoob.datamonitor.Common.getDateSuffix;
+import static com.drnoob.datamonitor.Common.formatOrdinalNumber;
 import static com.drnoob.datamonitor.Common.postNotification;
 import static com.drnoob.datamonitor.Common.setDataPlanNotification;
 import static com.drnoob.datamonitor.Common.setRefreshAlarm;
@@ -1164,11 +1164,11 @@ public class SetupFragment extends Fragment {
                                 intent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, ids);
                                 getContext().sendBroadcast(intent);
 
-                                String date = String.valueOf(datePicker.getDayOfMonth());
-                                String suffix = getDateSuffix(date);
+                                int date = datePicker.getDayOfMonth();
+                                String ordinal = formatOrdinalNumber(date);
 
                                 mUsageResetTime.setSummary(getContext().getString(R.string.label_reset_every_month,
-                                        date, suffix));
+                                        ordinal));
 
                                 dialog.dismiss();
 
@@ -1178,7 +1178,7 @@ public class SetupFragment extends Fragment {
                                 }
 
                                 snackbar = Snackbar.make(getActivity().findViewById(R.id.main_root),
-                                        getString(R.string.label_data_usage_reset_date_change, datePicker.getDayOfMonth(), suffix),
+                                        getString(R.string.label_data_usage_reset_date_change, ordinal),
                                         Snackbar.LENGTH_SHORT)
                                         .setAnchorView(getActivity().findViewById(R.id.bottomNavigationView));
                                 dismissOnClick(snackbar);
@@ -1700,12 +1700,11 @@ public class SetupFragment extends Fragment {
             if (PreferenceManager.getDefaultSharedPreferences(getContext()).getString(DATA_RESET, "null")
                     .equals(DATA_RESET_MONTHLY)) {
                 resetTitle = getContext().getString(R.string.setup_usage_reset_date);
-                String date = String.valueOf(PreferenceManager.getDefaultSharedPreferences(getContext())
-                        .getInt(DATA_RESET_DATE, 1));
-                String suffix = getDateSuffix(date);
+                int date = PreferenceManager.getDefaultSharedPreferences(getContext())
+                        .getInt(DATA_RESET_DATE, 1);
+                String ordinal = formatOrdinalNumber(date);
 
-                resetSummary = (getContext().getString(R.string.label_reset_every_month,
-                        date, suffix));
+                resetSummary = (getContext().getString(R.string.label_reset_every_month, ordinal));
             }
             else if (PreferenceManager.getDefaultSharedPreferences(getContext()).getString(DATA_RESET, "null")
                     .equals(DATA_RESET_CUSTOM)) {

--- a/app/src/main/java/com/drnoob/datamonitor/ui/fragments/SetupFragment.java
+++ b/app/src/main/java/com/drnoob/datamonitor/ui/fragments/SetupFragment.java
@@ -1165,7 +1165,7 @@ public class SetupFragment extends Fragment {
                                 getContext().sendBroadcast(intent);
 
                                 int date = datePicker.getDayOfMonth();
-                                String ordinal = formatOrdinalNumber(date);
+                                String ordinal = formatOrdinalNumber(date, requireContext());
 
                                 mUsageResetTime.setSummary(getContext().getString(R.string.label_reset_every_month,
                                         ordinal));
@@ -1702,7 +1702,7 @@ public class SetupFragment extends Fragment {
                 resetTitle = getContext().getString(R.string.setup_usage_reset_date);
                 int date = PreferenceManager.getDefaultSharedPreferences(getContext())
                         .getInt(DATA_RESET_DATE, 1);
-                String ordinal = formatOrdinalNumber(date);
+                String ordinal = formatOrdinalNumber(date, requireContext());
 
                 resetSummary = (getContext().getString(R.string.label_reset_every_month, ordinal));
             }

--- a/app/src/main/java/com/drnoob/datamonitor/ui/fragments/SetupFragment.java
+++ b/app/src/main/java/com/drnoob/datamonitor/ui/fragments/SetupFragment.java
@@ -21,6 +21,7 @@ package com.drnoob.datamonitor.ui.fragments;
 
 import static com.drnoob.datamonitor.Common.cancelDataPlanNotification;
 import static com.drnoob.datamonitor.Common.dismissOnClick;
+import static com.drnoob.datamonitor.Common.getDateSuffix;
 import static com.drnoob.datamonitor.Common.postNotification;
 import static com.drnoob.datamonitor.Common.setDataPlanNotification;
 import static com.drnoob.datamonitor.Common.setRefreshAlarm;
@@ -1164,20 +1165,7 @@ public class SetupFragment extends Fragment {
                                 getContext().sendBroadcast(intent);
 
                                 String date = String.valueOf(datePicker.getDayOfMonth());
-                                String suffix;
-
-                                if (date.endsWith("1")) {
-                                    suffix = "st";
-                                }
-                                else if (date.endsWith("2")) {
-                                    suffix = "nd";
-                                }
-                                else if (date.endsWith("3")) {
-                                    suffix = "rd";
-                                }
-                                else {
-                                    suffix = "th";
-                                }
+                                String suffix = getDateSuffix(date);
 
                                 mUsageResetTime.setSummary(getContext().getString(R.string.label_reset_every_month,
                                         date, suffix));
@@ -1714,20 +1702,7 @@ public class SetupFragment extends Fragment {
                 resetTitle = getContext().getString(R.string.setup_usage_reset_date);
                 String date = String.valueOf(PreferenceManager.getDefaultSharedPreferences(getContext())
                         .getInt(DATA_RESET_DATE, 1));
-                String suffix;
-
-                if (date.endsWith("1")) {
-                    suffix = "st";
-                }
-                else if (date.endsWith("2")) {
-                    suffix = "nd";
-                }
-                else if (date.endsWith("3")) {
-                    suffix = "rd";
-                }
-                else {
-                    suffix = "th";
-                }
+                String suffix = getDateSuffix(date);
 
                 resetSummary = (getContext().getString(R.string.label_reset_every_month,
                         date, suffix));

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -313,7 +313,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="@dimen/margin_large"
-                        android:text="@string/label_plan_details_title"
+                        android:text="@string/label_plan_details_title_unknown"
                         android:textAppearance="@style/TextAppearance.AppCompat.Title"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -392,7 +392,6 @@
     <string name="error_network_monitor_start">فشل بدء تشغيل \"مراقبة الشبكة\". افتح التطبيق للتحديث.</string>
     <string name="label_filter_app_usage">تصفية استخدام التطبيق</string>
     <string name="label_current_plan">الخطة الحالية</string>
-    <string name="label_plan_details_title">خطة %1$s نشطة</string>
     <string name="label_filter">المرشحات</string>
     <string name="home_plan_usage_details">%1$s مستخدمة | %2$s</string>
     <string name="label_plan_validity">صالح حتى %1$s|%2$s</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -204,13 +204,13 @@
     <string name="label_loading">جارِ التحميل…</string>
     <string name="donate_summary">"شراء قهوة لنا ، ما رأيك؟"</string>
     <string name="label_data_usage_reset_time_change">"ستتم إعادة تعيين استخدام البيانات كل %1$s عند %2$s"</string>
-    <string name="label_data_usage_reset_date_change">"ستتم إعادة تعيين استخدام البيانات في %1$d%2$s من كل شهر"</string>
+    <string name="label_data_usage_reset_date_change">"ستتم إعادة تعيين استخدام البيانات في %1$s من كل شهر"</string>
     <string name="ygorigor_summary">"المترجم الروماني"</string>
     <string name="johnsonran_summary">"مترجم صيني مبسط"</string>
     <string name="label_want_to_contribute_language">"لا يمكنك العثور على لغتك؟ ساعدنا بترجمة المحتوى إلى لغتك المحلية. انقر لمعرفة كيف."</string>
     <string name="current_language">"اللغة الحالية"</string>
     <string name="available_languages">"اللغات المتوفرة"</string>
-    <string name="label_reset_every_month">"%1$s%2$s من كل شهر"</string>
+    <string name="label_reset_every_month">"%1$s من كل شهر"</string>
     <string name="setup_usage_reset_date">"تاريخ إعادة تعيين استخدام البيانات"</string>
     <string name="system_data_usage">"استخدام بيانات النظام"</string>
     <string name="cracky5322_summary">"مترجم صيني تقليدي"</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -143,7 +143,7 @@
     <string name="monthly">Měsíčně</string>
     <string name="ltc_address_copied">Adresa peněženky Litecoin zkopírována do schránky</string>
     <string name="eth_address_copied">Adresa peněženky Ethereum zkopírována do schránky</string>
-    <string name="label_data_usage_reset_date_change">Využití dat se resetuje %1$d%2$s každý měsíc</string>
+    <string name="label_data_usage_reset_date_change">Využití dat se resetuje %1$s každý měsíc</string>
     <string name="label_widget_refreshed">Widget aktualizován</string>
     <string name="label_notification_enabled">Oznámení aplikace povolena</string>
     <string name="label_notification_cannot_disable_both">Nelze vypnout oba prvky</string>
@@ -230,7 +230,7 @@
     <string name="f_droid_page">Zobrazit aplikaci na F-Droid</string>
     <string name="f_droid_page_summary">Zobrazit aplikaci v oficiálním repozitáři F-Droid</string>
     <string name="fjuro_summary">Čeština</string>
-    <string name="label_reset_every_month">%1$s%2$s v každém měsíci</string>
+    <string name="label_reset_every_month">%1$s v každém měsíci</string>
     <string name="telegram_support">Podpora na Telegramu</string>
     <string name="system_theme_summary">Podle systému</string>
     <string name="label_update_available">Je dostupná nová verze!</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -380,7 +380,6 @@
     <string name="buymeacoffee_summary">Kupte mi kávu :)</string>
     <string name="label_plan_validity">Platí do %1$s | %2$s</string>
     <string name="always_show_total_summary">V oznámení se vždy zobrazí celková použitá data bez ohledu na vybrané možnosti.</string>
-    <string name="label_plan_details_title">Aktivní %1$s plán</string>
     <string name="home_plan_usage_details">%1$s využito | %2$s</string>
     <string name="U1M450W_summary">Uzbečtina</string>
     <string name="atharvshinde">Atharv Shinde</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -408,7 +408,6 @@
     <string name="label_upi">BHIM-UPI</string>
     <string name="home_plan_usage_details">%1$s verwendet | %2$s</string>
     <string name="error_alarm_permission_denied_feature_summary">Sie können diese Funktion nur nutzen, wenn Sie das Recht SCHEDULE_EXACT_ALARM haben.</string>
-    <string name="label_plan_details_title">%1$s Plan aktiv</string>
     <string name="error_alarm_permission_denied">Alarmerlaubnis verweigert!</string>
     <string name="error_alarm_permission_denied_summary">Sie haben versucht, eine Aktion auszuführen, für die die Berechtigung SCHEDULE_EXACT_ALARM erforderlich ist, die der App nicht erteilt wurde. Klicken Sie hier, um die Berechtigung zu erteilen.</string>
     <string name="error_alarm_permission_denied_dialog_summary">Data Monitor benötigt die Berechtigung SCHEDULE_EXACT_ALARM, um richtig zu funktionieren. Sie können die App trotzdem verwenden, aber einige Funktionen funktionieren möglicherweise nicht richtig.</string>
@@ -466,4 +465,8 @@
     <string name="action_apply_filter">Filter anwenden</string>
     <string name="error_invalid_session">Ungültige Sitzungsdauer.</string>
     <string name="xxx_summary">Russisch</string>
+    <string name="label_plan_details_title_unknown">Unbekannter Plan aktiv</string>
+    <string name="label_plan_details_title_monthly">Monatlicher Plan aktiv</string>
+    <string name="label_plan_details_title_daily">Täglicher Plan aktiv</string>
+    <string name="label_plan_details_title_custom">Benutzerdefinierter Plan aktiv</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -172,7 +172,7 @@
     <string name="remaining_data_info_enabled">Restliche Dateninfo aktiviert</string>
     <string name="body_data_warning_notification">Sie haben %1$d%% Ihres Datenlimits ausgeschöpft</string>
     <string name="extra_optimisation_tips">Zusätzliche Optimierungstipps</string>
-    <string name="label_data_usage_reset_date_change">Die Datennutzung wird am %1$d%2$s eines jeden Monats zurückgesetzt</string>
+    <string name="label_data_usage_reset_date_change">Die Datennutzung wird am %1$s eines jeden Monats zurückgesetzt</string>
     <string name="day">Tag</string>
     <string name="label_translators">Übersetzer</string>
     <string name="label_network_signal_notification_enabled">Live-Netzwerkgeschwindigkeit aktiviert</string>
@@ -225,7 +225,7 @@
     <string name="isp_region">Region</string>
     <string name="app_label_screen_time">Bildschirmzeit: %1$s</string>
     <string name="ygorigor_summary">Rumänisch</string>
-    <string name="label_reset_every_month">%1$s%2$s eines jeden Monats</string>
+    <string name="label_reset_every_month">%1$s eines jeden Monats</string>
     <string name="system_data_usage">Daten-Nutzung von System</string>
     <string name="louis_leblanc_summary">Französisch</string>
     <string name="network_speed_title">Netzwerkgeschwindigkeit: %1$s</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -121,7 +121,7 @@
 \nNo se recogen datos personales.</string>
     <string name="upi_unknown_error">Error desconocido.
 \nInténtalo de nuevo o de otro método.</string>
-    <string name="label_data_usage_reset_date_change">El uso de datos se restablecerá el %1$d%2$s de cada mes</string>
+    <string name="label_data_usage_reset_date_change">El uso de datos se restablecerá el %1$s de cada mes</string>
     <string name="remaining_data_info_enabled">Información de datos restantes habilitada</string>
     <string name="title_data_usage_notification">Uso de datos hoy: %1$s</string>
     <string name="label_data_remaining">%1$s restante</string>
@@ -244,7 +244,7 @@
     <string name="swipe_right_to_delete">Desliza el dedo hacia la derecha para eliminar un elemento</string>
     <string name="current_language">Actual</string>
     <string name="available_languages">Disponible</string>
-    <string name="label_reset_every_month">%1$s%2$s de cada mes</string>
+    <string name="label_reset_every_month">%1$s de cada mes</string>
     <string name="setup_usage_reset_date">Fecha de restablecimiento del uso de datos</string>
     <string name="system_data_usage">Uso de datos del sistema</string>
     <string name="cracky5322_summary">Chino tradicional</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -400,7 +400,6 @@
     <string name="label_plan_validity">Válido hasta el %1$s | %2$s</string>
     <string name="app_label_combined_total">Uso total de datos: %1$s</string>
     <string name="error_alarm_permission_denied">¡Permiso de alarma denegado!</string>
-    <string name="label_plan_details_title">%1$s plan activo</string>
     <string name="home_plan_usage_details">%1$s utilizado | %2$s</string>
     <string name="always_show_total_summary">Mostrar siempre el total de datos utilizados en la notificación, independientemente de las opciones seleccionadas.</string>
     <string name="label_current_plan">Plan actual</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -345,7 +345,7 @@
     <string name="error_network_monitor_start">Échec du démarrage de Network Monitor. Ouvrez l\'application pour actualiser.</string>
     <string name="label_filter_app_usage">Flitrer l\'Utilisation des Applications</string>
     <string name="label_current_plan">Forfait Actuel</string>
-    <string name="home_plan_usage_details">%1$s consommés |%2$s</string>
+    <string name="home_plan_usage_details">%1$s consommés | %2$s</string>
     <string name="label_plan_validity">Valable jusqu\'au %1$s | %2$s</string>
     <string name="always_show_total_summary">Toujours afficher le total des données consommées, quelles que soient les options sélectionnées.</string>
     <string name="app_label_combined_total">Total de la consommation des données : %1$s</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -204,13 +204,13 @@
     <string name="label_loading">Chargement…</string>
     <string name="donate_summary">"Payez nous un café, peut-être ?"</string>
     <string name="label_data_usage_reset_time_change">"L'utilisation des données sera remise à zéro chaque %1$s à %2$s"</string>
-    <string name="label_data_usage_reset_date_change">"L'utilisation des données sera remise à zéro le %1$d%2$s de chaque mois"</string>
+    <string name="label_data_usage_reset_date_change">L\'utilisation des données sera remise à zéro le %1$s de chaque mois</string>
     <string name="ygorigor_summary">"Traducteur roumain"</string>
     <string name="johnsonran_summary">"Traducteur de chinois simplifié"</string>
     <string name="label_want_to_contribute_language">"Vous ne trouvez pas votre langue ? Aidez-nous en traduisant les contenus vers votre langue. Cliquez pour savoir comment."</string>
     <string name="current_language">"Langue actuelle"</string>
     <string name="available_languages">"Langues disponibles"</string>
-    <string name="label_reset_every_month">"%1$s%2$s de chaque mois"</string>
+    <string name="label_reset_every_month">"%1$s de chaque mois"</string>
     <string name="setup_usage_reset_date">"Remise à zéro de l'utilisation des données"</string>
     <string name="system_data_usage">"Utilisation des données par le système"</string>
     <string name="cracky5322_summary">"Traducteur en chinois traditionnel"</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -45,7 +45,7 @@
     <string name="setup_image_footer">"Les widgets et/ou les notifications peuvent fournir un accès facile à la quantité de données que vous utilisez"</string>
     <string name="heading_data_reset">"Remise à zéro des données"</string>
     <string name="daily">"Quotidiennement"</string>
-    <string name="monthly">"Hebdomadairement"</string>
+    <string name="monthly">Mensuel</string>
     <string name="heading_data_limit">"Limite de données"</string>
     <string name="data_type_mb">"Mo"</string>
     <string name="data_type_gb">"Go"</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -345,7 +345,6 @@
     <string name="error_network_monitor_start">Échec du démarrage de Network Monitor. Ouvrez l\'application pour actualiser.</string>
     <string name="label_filter_app_usage">Flitrer l\'Utilisation des Applications</string>
     <string name="label_current_plan">Forfait Actuel</string>
-    <string name="label_plan_details_title">%1$s forfait actif</string>
     <string name="home_plan_usage_details">%1$s consommés |%2$s</string>
     <string name="label_plan_validity">Valable jusqu\'au %1$s | %2$s</string>
     <string name="always_show_total_summary">Toujours afficher le total des données consommées, quelles que soient les options sélectionnées.</string>
@@ -467,4 +466,8 @@
     <string name="jean_mareilles">Jean Mareilles</string>
     <string name="time">Horaires</string>
     <string name="dan">Dan</string>
+    <string name="label_plan_details_title_unknown">Forfait inconnu actif</string>
+    <string name="label_plan_details_title_monthly">Forfait mensuel actif</string>
+    <string name="label_plan_details_title_daily">Forfait quotidien actif</string>
+    <string name="label_plan_details_title_custom">Forfait personnalisé actif</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -159,7 +159,7 @@
     <string name="label_want_to_contribute_language">अपनी भाषा में एप्लिकेशन को अनुवाद करने में मदद करने के लिए यहां क्लिक करें।</string>
     <string name="current_language">वर्तमान</string>
     <string name="available_languages">उपलब्ध</string>
-    <string name="label_reset_every_month">हर महीने का %1$s%2$s</string>
+    <string name="label_reset_every_month">हर महीने का %1$s</string>
     <string name="setup_usage_reset_date">डेटा उपयोग रीसेट दिनांक</string>
     <string name="system_data_usage">सिस्टम डेटा उपयोग</string>
     <string name="cracky5322_summary">पारंपरिक चीनी</string>
@@ -285,7 +285,7 @@
     <string name="upi_unknown_error">अज्ञात त्रुटि।
 \nकृपया पुन: प्रयास करें या कोई अन्य विधि।</string>
     <string name="label_no_additional_lang">एप्लिकेशन का अनुवाद करने में मदद करने के लिए यहां क्लिक करें।</string>
-    <string name="label_data_usage_reset_date_change">डेटा उपयोग हर महीने %1$d%2$s पर रीसेट किया जाएगा</string>
+    <string name="label_data_usage_reset_date_change">डेटा उपयोग हर महीने %1$s पर रीसेट किया जाएगा</string>
     <string name="remaining_data_info_enabled">शेष डेटा जानकारी सक्षम</string>
     <string name="testing_download">डाउनलोड गति का परीक्षण किया जा रहा है</string>
     <string name="overview_thursday">गुरु</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -139,7 +139,7 @@
     <string name="label_widget_refresh_interval_change">Widget akan diperbarui setiap %1$s</string>
     <string name="label_notification_refresh_interval_change">Pemberitahuan akan diperbarui setiap %1$s</string>
     <string name="label_data_usage_reset_time_change">Mengatur ulang penggunaan data setiap %1$s pada %2$s</string>
-    <string name="label_data_usage_reset_date_change">Penggunaan data akan diatur ulang di %1$d%2$s setiap bulannya</string>
+    <string name="label_data_usage_reset_date_change">Penggunaan data akan diatur ulang di %1$s setiap bulannya</string>
     <string name="remaining_data_info_enabled">Info data yang tersisa diaktifkan</string>
     <string name="label_no_additional_lang">Klik di sini untuk membantu menerjemahkan aplikasi.</string>
     <string name="remaining_data_info_disabled">Info data yang tersisa dinonaktifkan</string>
@@ -212,7 +212,7 @@
     <string name="read_phone_state_permission">Izin untuk membaca status ponsel</string>
     <string name="johnsonran_summary">Cina Sederhana</string>
     <string name="network_speed_download">Unduh: %1$s</string>
-    <string name="label_reset_every_month">%1$s%2$s dari setiap bulan</string>
+    <string name="label_reset_every_month">%1$s dari setiap bulan</string>
     <string name="network_signal_summary">Fitur beta</string>
     <string name="louis_leblanc_summary">Prancis</string>
     <string name="label_want_to_contribute_language">Klik di sini untuk membantu menerjemahkan aplikasi ke dalam bahasa Anda.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -204,13 +204,13 @@
     <string name="label_loading">Caricamento…</string>
     <string name="donate_summary">"Vorresti offrirci un caffè?"</string>
     <string name="label_data_usage_reset_time_change">"L'uso dei dati sarà resettato ogni %1$s alle %2$s"</string>
-    <string name="label_data_usage_reset_date_change">L\'uso dei dati sarà resettato il %1$d%2$s di ogni mese</string>
+    <string name="label_data_usage_reset_date_change">L\'uso dei dati sarà resettato il %1$s di ogni mese</string>
     <string name="ygorigor_summary">"Traduttore del romeno"</string>
     <string name="johnsonran_summary">"Traduttore del cinese semplificato"</string>
     <string name="label_want_to_contribute_language">"Non trovi la tua lingua? Aiutaci traducendo i contenuti nella tua lingua. Clicca qui per sapere come."</string>
     <string name="current_language">"Lingua scelta"</string>
     <string name="available_languages">"Lingue disponibili"</string>
-    <string name="label_reset_every_month">"%1$s%2$s di ogni mese"</string>
+    <string name="label_reset_every_month">"%1$s di ogni mese"</string>
     <string name="holydemon_summary">Malayalam</string>
     <string name="liviogasp_summary">Italiano</string>
     <string name="comradekingu_summary">Supporto alla traduzione</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -156,7 +156,6 @@
     <string name="overview_friday">שישי</string>
     <string name="error_alarm_permission_denied_feature_summary">לא ניתן להשתמש בתכולה זו מבלי להתיר הרשאת SCHEDULE_EXACT_ALARM.</string>
     <string name="rate_app">דרגו את היישום ב-Google Play</string>
-    <string name="label_plan_details_title">%1$s חבילה פעילה</string>
     <string name="holydemon_summary">מלאיאלאם</string>
     <string name="gallegonovato_summary">ספרדית</string>
     <string name="Kefir2105_summary">אוקראינית</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -130,7 +130,7 @@
     <string name="report_summary">שליחת דיווח על באגים או בקשה לתכולות</string>
     <string name="home_wifi_data_received">%1$s
 \nהתקבלו</string>
-    <string name="label_data_usage_reset_date_change">השימוש בנתונים יאופס ב-%1$d%2$s בכל חודש</string>
+    <string name="label_data_usage_reset_date_change">השימוש בנתונים יאופס ב-%1$s בכל חודש</string>
     <string name="action_update">עדכון</string>
     <string name="app_data_usage">השימוש ביישום</string>
     <string name="data_alert_summary">הצגת התראה כאשר מיכסת הנתונים הסתיימה</string>
@@ -304,7 +304,7 @@
     <string name="title_data_warning_notification">אזהרת שימוש בנתונים</string>
     <string name="label_data_remaining">%1$s נותרו</string>
     <string name="always_show_total_summary">הצגת סך הנתונים שנוצלו בהתראה תמיד ללא תלות באפשרויות שנבחרו.</string>
-    <string name="label_reset_every_month">%1$s%2$s בכל חודש</string>
+    <string name="label_reset_every_month">%1$s בכל חודש</string>
     <string name="network_signal_summary">תכולה נסיונית</string>
     <string name="heading_data_reset_custom_counter">תוקף החבילה</string>
     <string name="report_mail_summary">שליחת דו\"ח הקריסה בדוא\"ל</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -152,7 +152,7 @@
     <string name="available_languages">利用可能</string>
     <string name="error_permission_denied">権限が拒否されました。手動で許可してください。</string>
     <string name="current_language">現在</string>
-    <string name="label_reset_every_month">毎月%1$s%2$s</string>
+    <string name="label_reset_every_month">毎月%1$s</string>
     <string name="setup_usage_reset_date">データ使用量のリセット日</string>
     <string name="system_data_usage">システムのデータ使用量</string>
     <string name="cracky5322_summary">中国語(繁体字)</string>
@@ -200,7 +200,7 @@
     <string name="remaining_data_info_enabled">データ残量情報が有効です</string>
     <string name="remaining_data_info_disabled">データ残量情報が無効です</string>
     <string name="label_notification_enabled">データ使用量モニターの通知は有効です</string>
-    <string name="label_data_usage_reset_date_change">データ使用量は毎月%1$d%2$sにリセットされます</string>
+    <string name="label_data_usage_reset_date_change">データ使用量は毎月%1$sにリセットされます</string>
     <string name="label_monitoring_no_plan">監視を始めるにはデータプランを追加してください</string>
     <string name="label_add_data_plan_first">最初にデータプランを追加してください</string>
     <string name="label_data_remaining_used_excess">超過%1$s</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -116,7 +116,7 @@
 \n다시 시도하거나 다른 방법을 시도하십시오.</string>
     <string name="notification_disabled">데이터 모니터 알림 사용 안 함</string>
     <string name="label_notification_refresh_interval_change">알림은 %1$s마다 업데이트됩니다</string>
-    <string name="label_data_usage_reset_date_change">매월 %1$d%2$s에서 데이터 사용량이 재설정됩니다.</string>
+    <string name="label_data_usage_reset_date_change">매월 %1$s에서 데이터 사용량이 재설정됩니다.</string>
     <string name="remaining_data_info_enabled">나머지 데이터 정보 사용</string>
     <string name="remaining_data_info_disabled">나머지 데이터 정보 사용 안 함</string>
     <string name="label_widget_refreshed">위젯 새로 고침</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -392,7 +392,6 @@
     <string name="label_filter">ഫിൽറ്റർ</string>
     <string name="label_filter_app_usage">ആപ്പ് ഉപയോഗം ഫിൽറ്റർ ചെയ്യുക</string>
     <string name="label_current_plan">നിലവിലെ പ്ലാൻ</string>
-    <string name="label_plan_details_title">%1$s പ്ലാൻ സജീവമാണ്</string>
     <string name="home_plan_usage_details">%1$s ഉപയോഗിച്ചു | %2$s</string>
     <string name="label_plan_validity">%1$s വരെ സാധുതയുണ്ട്</string>
     <string name="always_show_total">എല്ലായ്‌പ്പോഴും ആകെ കാണിക്കുക</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -204,13 +204,13 @@
     <string name="label_loading">ലോഡിംഗ്…</string>
     <string name="donate_summary">"ഞങ്ങൾക്ക് ഒരു കോഫി വാങ്ങിത്തരിക, ഒരുപക്ഷേ?"</string>
     <string name="label_data_usage_reset_time_change">"ഓരോ %1$s സമയത്തും %2$s-ന് ഡാറ്റ ഉപയോഗം പുനഃസജ്ജമാക്കും"</string>
-    <string name="label_data_usage_reset_date_change">"എല്ലാ മാസവും %1$d%2$s-ന് ഡാറ്റ ഉപയോഗം റീസെറ്റ് ചെയ്യും"</string>
+    <string name="label_data_usage_reset_date_change">"എല്ലാ മാസവും %1$s-ന് ഡാറ്റ ഉപയോഗം റീസെറ്റ് ചെയ്യും"</string>
     <string name="ygorigor_summary">"റൊമാനിയൻ പരിഭാഷകൻ"</string>
     <string name="johnsonran_summary">"സിംപ്ളിഫൈഡ് ചൈനീസ് വിവർത്തകൻ"</string>
     <string name="label_want_to_contribute_language">"നിങ്ങളുടെ ഭാഷ കണ്ടെത്താൻ കഴിയുന്നില്ലേ? നിങ്ങളുടെ പ്രാദേശിക ഭാഷയിലേക്ക് ഉള്ളടക്കങ്ങൾ വിവർത്തനം ചെയ്തുകൊണ്ട് ഞങ്ങളെ സഹായിക്കൂ. എങ്ങനെയെന്നറിയാൻ ക്ലിക്ക് ചെയ്യുക."</string>
     <string name="current_language">"നിലവിലെ ഭാഷ"</string>
     <string name="available_languages">"ലഭ്യമായ ഭാഷകൾ"</string>
-    <string name="label_reset_every_month">"എല്ലാ മാസവും %1$s%2$s"</string>
+    <string name="label_reset_every_month">"എല്ലാ മാസവും %1$s"</string>
     <string name="setup_usage_reset_date">"ഡാറ്റ ഉപയോഗ പുനഃസജ്ജീകരണ തീയതി"</string>
     <string name="system_data_usage">"സിസ്റ്റം ഡാറ്റ ഉപയോഗം"</string>
     <string name="cracky5322_summary">"പരമ്പരാഗത ചൈനീസ് വിവർത്തകൻ"</string>

--- a/app/src/main/res/values-mr/strings.xml
+++ b/app/src/main/res/values-mr/strings.xml
@@ -20,7 +20,7 @@
     <string name="label_changelogs">नवीन काय आहे ते शोधा</string>
     <string name="notification_disabled">डेटा मॉनिटर सूचना अक्षम</string>
     <string name="label_widget_refresh_interval_change">विजेट प्रत्येक %1$s अद्यतनित केले जाईल</string>
-    <string name="label_data_usage_reset_date_change">डेटा वापर दर महिन्याच्या %1$d%2$s रोजी रीसेट केला जाईल</string>
+    <string name="label_data_usage_reset_date_change">डेटा वापर दर महिन्याच्या %1$s रोजी रीसेट केला जाईल</string>
     <string name="label_monitoring_no_plan">देखरेख सुरू करण्यासाठी डेटा योजना जोडा</string>
     <string name="label_widget_refreshed">विजेट ताजेतवाने</string>
     <string name="label_notification_refresh_interval_change">सूचना प्रत्येक %1$s अद्यतनित केली जाईल</string>
@@ -106,7 +106,7 @@
     <string name="system_data_usage">सिस्टम डेटा वापर</string>
     <string name="Kefir2105_summary">युक्रेनियन</string>
     <string name="app_label_screen_time">स्क्रीन वेळ: %1$s</string>
-    <string name="label_reset_every_month">प्रत्येक महिन्याचा %1$s%2$s</string>
+    <string name="label_reset_every_month">प्रत्येक महिन्याचा %1$s</string>
     <string name="Master2050_summary">पारंपारिक चीनी, पोर्तुगीज, फ्रेंच, नॉर्वेजियन बोक्मासेल, स्पॅनिश, जर्मन, रोमानियाई, कोरियन, तुर्की, सरलीकृत चिनी, युक्रेनियन, हिंदी, रशियन, अरबी</string>
     <string name="refresh_list">यादी रिफ्रेश करा</string>
     <string name="network_ip">नेटवर्क आयपी</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -207,7 +207,7 @@
     <string name="upi_app_not_found">Installer et program som kan gjøre dette først</string>
     <string name="upi_unknown_error">Ukjent feil.
 \nPrøv igjen eller en annen metode.</string>
-    <string name="label_data_usage_reset_date_change">Databruk vil bli tilbakestilt %1$d%2$s hver måned</string>
+    <string name="label_data_usage_reset_date_change">Databruk vil bli tilbakestilt %1$s hver måned</string>
     <string name="error_permission_denied">Tilgang nektet. Innvilg den manuelt.</string>
     <string name="oem_battery_settings">OEM-batteri-innstillinger</string>
     <string name="overview_tuesday">Tir</string>
@@ -231,7 +231,7 @@
     <string name="ygorigor_summary">Rumensk</string>
     <string name="network_speed_upload">Opplasting: %1$s</string>
     <string name="available_languages">Tilgjengelig</string>
-    <string name="label_reset_every_month">%1$s%2$s i hver måned</string>
+    <string name="label_reset_every_month">%1$s i hver måned</string>
     <string name="cracky5322_summary">Tradisjonell kinesisk</string>
     <string name="network_speed_title">Nettverkshastighet: %1$s</string>
     <string name="network_speed_download">Nedlasting: %1$s</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -162,7 +162,7 @@
     <string name="label_data_usage_reset_time_change">Reset het dataverbruik elke %1$s bij %2$s</string>
     <string name="usage_access_body">Vereist om de app uit te voeren, omdat deze app-gebruiksstatistieken verzamelt. 
 \nEr worden geen persoonsgegevens verzameld.</string>
-    <string name="label_data_usage_reset_date_change">Data gebruik wordt iedere maand op %1$d%2$s opnieuw ingesteld</string>
+    <string name="label_data_usage_reset_date_change">Data gebruik wordt iedere maand op %1$s opnieuw ingesteld</string>
     <string name="remaining_data_info_enabled">Resterende gegevensinformatie ingeschakeld</string>
     <string name="remaining_data_info_disabled">Resterende gegevensinformatie ingeschakeld</string>
     <string name="label_monitoring_no_plan">Data gegevens toevoegen om de monitoring te starten</string>
@@ -221,7 +221,7 @@
     <string name="ygorigor_summary">Romeens</string>
     <string name="current_language">Huidig</string>
     <string name="available_languages">Beschikbaar</string>
-    <string name="label_reset_every_month">%1$s%2$s van iedere maand</string>
+    <string name="label_reset_every_month">%1$s van iedere maand</string>
     <string name="setup_usage_reset_date">Resetdatum voor gegevensgebruik</string>
     <string name="system_data_usage">Gebruik van systeemgegevens</string>
     <string name="cracky5322_summary">Traditioneel Chinees</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -97,7 +97,7 @@
     <string name="app_data_usage">Użycie aplikacji</string>
     <string name="settings">Opcje</string>
     <string name="label_system_apps">Aplikacje systemowe</string>
-    <string name="label_data_usage_reset_date_change">Użycie danych będzie resetowane w %1$d%2$s każdego miesiąca</string>
+    <string name="label_data_usage_reset_date_change">Użycie danych będzie resetowane w %1$s każdego miesiąca</string>
     <string name="label_setup_notification_first">Najpierw włącz powiadomienie</string>
     <string name="label_data_plan_saved">Plan danych zapisany</string>
     <string name="month">miesiąc</string>
@@ -216,7 +216,7 @@
     <string name="johnsonran_summary">Chiński uproszczony</string>
     <string name="ygorigor_summary">Rumuński</string>
     <string name="label_want_to_contribute_language">Kliknij, aby pomóc w tłumaczeniu tej aplikacji na twój język.</string>
-    <string name="label_reset_every_month">%1$s%2$s każdego miesiąca</string>
+    <string name="label_reset_every_month">%1$s każdego miesiąca</string>
     <string name="network_speed_download">Pobieranie: %1$s</string>
     <string name="network_signal_summary">Funkcja beta</string>
     <string name="network_speed_title">Prędkość sieci: %1$s</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -330,7 +330,6 @@
     <string name="error_network_monitor_start">Nie udało się uruchomić monitor sieci. Otwórz aplikację, aby go odświeżyć.</string>
     <string name="label_filter_app_usage">Filtruj użycie aplikacji</string>
     <string name="always_show_total">Zawsze pokazuj całość</string>
-    <string name="label_plan_details_title">Plan %1$s jest aktywny</string>
     <string name="home_plan_usage_details">Użyto %1$s | %2$s</string>
     <string name="setup_app_data_usage_alert">Ostrzeżenie o użyciu aplikacji</string>
     <string name="testing_download">Testowanie prędkości pobierania</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -239,7 +239,7 @@ Perguntas e respostas, ajuda e solução de problemas
 "O uso de dados será redefinido a cada %1$s em %2$s"
 </string>
     <string name="label_data_usage_reset_date_change">
-"O uso de dados será redefinido em %1$d%2$s de cada mês"
+"O uso de dados será redefinido em %1$s de cada mês"
 </string>
     <string name="ygorigor_summary">"Tradutor romeno"</string>
     <string name="johnsonran_summary">"Tradutor chinês simplificado"</string>
@@ -248,7 +248,7 @@ Perguntas e respostas, ajuda e solução de problemas
 </string>
     <string name="current_language">"Idioma atual"</string>
     <string name="available_languages">"Idiomas disponíveis"</string>
-    <string name="label_reset_every_month">"%1$s%2$s de cada mês"</string>
+    <string name="label_reset_every_month">"%1$s de cada mês"</string>
     <string name="setup_usage_reset_date">"Data de redefinição do uso de dados"</string>
     <string name="system_data_usage">"Uso de dados do sistema"</string>
     <string name="cracky5322_summary">"Tradutor de chinês tradicional"</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -356,4 +356,8 @@
     <string name="MarongHappy">JungHee Lee</string>
     <string name="action_delete">Șterge</string>
     <string name="save_results_summary">Salvează rezultatele diagnosticării rețelei</string>
+    <string name="label_plan_details_title_unknown">Plan necunoscut activ</string>
+    <string name="label_plan_details_title_monthly">Plan lunar activ</string>
+    <string name="label_plan_details_title_daily">Plan zilnic activ</string>
+    <string name="label_plan_details_title_custom">Plan personalizat activ</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -217,7 +217,7 @@
     <string name="label_select_app">Selectați aplicația</string>
     <string name="label_copy_logs">Copiere jurnale</string>
     <string name="settings_upload_server">Încărcare server</string>
-    <string name="label_data_usage_reset_date_change">Utilizarea datelor va fi resetată pe %1$d%2$s din fiecare lună</string>
+    <string name="label_data_usage_reset_date_change">Utilizarea datelor va fi resetată pe %1$s din fiecare lună</string>
     <string name="setup_usage_reset_date">Data de resetare a utilizării datelor</string>
     <string name="label_network_signal_notification_disabled">Viteza rețelei live a fost dezactivată</string>
     <string name="network_signal_summary">Caracteristică beta</string>
@@ -292,7 +292,7 @@
     <string name="label_select_start_date">Selectați data de început</string>
     <string name="label_plan_end_date">Selectați data de sfârșit</string>
     <string name="ygorigor_summary">Română</string>
-    <string name="label_reset_every_month">%1$s %2$s din fiecare lună</string>
+    <string name="label_reset_every_month">%1$s din fiecare lună</string>
     <string name="cracky5322_summary">Chineză tradițională</string>
     <string name="network_speed_upload">Încărcare: %1$s</string>
     <string name="network_speed_download">Descărcați: %1$s</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -190,7 +190,7 @@
     <string name="eth_address_copied">Адрес кошелька Ethereum скопирован в буфер обмена</string>
     <string name="app_data_usage">Использование данных приложениями</string>
     <string name="label_notification_refresh_interval_change">Уведомление будет обновляться каждые %1$s</string>
-    <string name="label_data_usage_reset_date_change">Использование данных будет обнуляться %1$d%2$s числа каждого месяца</string>
+    <string name="label_data_usage_reset_date_change">Использование данных будет обнуляться %1$s числа каждого месяца</string>
     <string name="remaining_data_info_enabled">Информация об остатке данных включена</string>
     <string name="label_data_plan_saved">Тарифный план сохранён</string>
     <string name="title_data_usage_notification">Использовано данных за сегодня: %1$s</string>
@@ -214,7 +214,7 @@
     <string name="connection_error">Не удалось подключиться.
 \nПожалуйста, убедитесь, что вы подключены к Интернету.</string>
     <string name="no_network_connection">Не обнаружено сетевое подключение!</string>
-    <string name="label_reset_every_month">%1$s%2$s каждого месяца</string>
+    <string name="label_reset_every_month">%1$s каждого месяца</string>
     <string name="app_label_background_time">Фоновое использование: %1$s</string>
     <string name="ygorigor_summary">Румынский</string>
     <string name="system_data_usage">Использование системных данных</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -369,7 +369,6 @@
     <string name="xmr_address_copied">Адрес кошелька Monero скопирован в буфер обмена</string>
     <string name="tadekdudek_summary">Польский</string>
     <string name="error_network_monitor_start">Не удалось запустить Network Monitor. Откройте приложение для обновления.</string>
-    <string name="label_plan_details_title">План %1$s активен</string>
     <string name="home_plan_usage_details">%1$s использовано | %2$s</string>
     <string name="label_plan_validity">Действует до %1$sb | %2$s</string>
     <string name="always_show_total">Всегда показывать общее количество</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -139,7 +139,7 @@
     <string name="label_no_additional_lang">Uygulamayı çevirmeye yardımcı olmak için buraya tıklayın.</string>
     <string name="notification_disabled">Veri monitörü bildirimi devre dışı</string>
     <string name="label_notification_refresh_interval_change">Bildirim her %1$s güncellenecektir</string>
-    <string name="label_data_usage_reset_date_change">Veri kullanımı her ayın %1$d%2$s tarihinde sıfırlanacaktır</string>
+    <string name="label_data_usage_reset_date_change">Veri kullanımı her ayın %1$s tarihinde sıfırlanacaktır</string>
     <string name="remaining_data_info_enabled">Kalan veri bilgisi etkin</string>
     <string name="remaining_data_info_disabled">Kalan veri bilgisi devre dışı</string>
     <string name="itsdrnoob">Dr.NooB</string>
@@ -253,7 +253,7 @@
     <string name="dark_theme_summary">Koyu tema seçildi</string>
     <string name="holydemon_summary">Malayalamca</string>
     <string name="body_app_data_warning_notification">%1$s veri kotasını kullandı</string>
-    <string name="label_reset_every_month">Her ayın %1$s%2$s</string>
+    <string name="label_reset_every_month">Her ayın %1$s</string>
     <string name="f_droid_page">Uygulamayı F-Droid\'de görüntüle</string>
     <string name="f_droid_page_summary">Uygulamaya resmi F-Droid deposunda göz atın</string>
     <string name="device_info_content_label">Cihaz bilgileri\'ne nelerin dahil olduğunu görme</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -355,7 +355,6 @@
     <string name="error_network_monitor_start">Veri İzleyici başlatılamadı. Yenilemek için uygulamayı açın.</string>
     <string name="label_filter">Filtrele</string>
     <string name="label_current_plan">Mevcut Plan</string>
-    <string name="label_plan_details_title">%1$s planı etkin</string>
     <string name="home_plan_usage_details">%1$s kullanıldı | %2$s</string>
     <string name="label_plan_validity">%1$s tarihine kadar geçerli | %2$s</string>
     <string name="always_show_total">Her zaman toplamı göster</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -151,7 +151,7 @@
     <string name="upi_unknown_error">Невідома помилка.
 \nБудь ласка, спробуйте ще раз або використовуйте інший спосіб.</string>
     <string name="label_widget_refresh_interval_change">Віджет буде оновлюватися кожні %1$s</string>
-    <string name="label_data_usage_reset_date_change">Використання даних буде обнулятися %1$d%2$s числа кожного місяця</string>
+    <string name="label_data_usage_reset_date_change">Використання даних буде обнулятися %1$s числа кожного місяця</string>
     <string name="label_data_usage_reset_time_change">Скидання використання даних кожні %1$s при %2$s</string>
     <string name="remaining_data_info_enabled">Інформація про залишок даних увімкнена</string>
     <string name="remaining_data_info_disabled">Інформація про залишок даних відключена</string>
@@ -175,7 +175,7 @@
     <string name="setup_app_data_usage_alert">Повідомлення про використання даних застосунку</string>
     <string name="current_language">Поточний</string>
     <string name="available_languages">Доступне</string>
-    <string name="label_reset_every_month">%1$s%2$s кожного місяця</string>
+    <string name="label_reset_every_month">%1$s кожного місяця</string>
     <string name="setup_usage_reset_date">Дата скидання використання даних</string>
     <string name="system_data_usage">Використання системних даних</string>
     <string name="cracky5322_summary">Китайська (традиційна)</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -363,7 +363,6 @@
     <string name="label_filter_app_usage">Фільтрувати використання застосунків</string>
     <string name="label_filter">Фільтр</string>
     <string name="label_current_plan">Поточний план</string>
-    <string name="label_plan_details_title">План %1$s активний</string>
     <string name="app_label_combined_total">Загальне використання даних: %1$s</string>
     <string name="error_alarm_permission_denied_summary">Ви спробували виконати дію, яка вимагає дозволу SCHEDULE_EXACT_ALARM, який не надано застосунку. Натисніть тут, щоб надати дозвіл.</string>
     <string name="error_alarm_permission_denied_dialog_summary">Для належної роботи Data Monitor потрібен дозвіл SCHEDULE_EXACT_ALARM. Ви все ще можете використовувати застосунок, але деякі функції можуть не працювати належним чином.</string>

--- a/app/src/main/res/values-uz/strings.xml
+++ b/app/src/main/res/values-uz/strings.xml
@@ -140,7 +140,7 @@
     <string name="label_widget_refresh_interval_change">Vidjet har %1$s da yangilanadi</string>
     <string name="label_notification_refresh_interval_change">Bildirishnoma har %1$s da yangilanadi</string>
     <string name="label_data_usage_reset_time_change">Trafikni har %1$s %2$s da yangilanadi</string>
-    <string name="label_data_usage_reset_date_change">Trafik har oyning %1$d %2$s sanasida yangilanadi</string>
+    <string name="label_data_usage_reset_date_change">Trafik har oyning %1$s sanasida yangilanadi</string>
     <string name="remaining_data_info_enabled">Qolgan trafik ma\'lumoti yoqildi</string>
     <string name="remaining_data_info_disabled">Qolgan trafik ma\'lumoti o\'chirildi</string>
     <string name="label_monitoring_no_plan">Nazorat qilishni boshlash uchun trafik rejasini qo\'shing</string>
@@ -217,7 +217,7 @@
     <string name="label_want_to_contribute_language">Ilovani o\'z tilingizga tarjima qilish uchun buyerga bosing.</string>
     <string name="current_language">Hozrgi</string>
     <string name="available_languages">Mavjud</string>
-    <string name="label_reset_every_month">Har oy %1$s%2$s</string>
+    <string name="label_reset_every_month">Har oy %1$s</string>
     <string name="setup_usage_reset_date">Trafik yangilanish sanasi</string>
     <string name="system_data_usage">Tizim trafigi</string>
     <string name="cracky5322_summary">Milliy xitoy</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -103,7 +103,7 @@
     <string name="remaining_data_info_enabled">Đã bật thông tin dữ liệu còn lại</string>
     <string name="label_add_data_plan_first">Hãy thiết lập gói dữ liệu trước</string>
     <string name="notification_disabled">Thông báo giám sát dữ liệu đã tắt</string>
-    <string name="label_data_usage_reset_date_change">Dữ liệu sử dụng sẽ được đặt lại vào %1$d%2$s của mỗi tháng</string>
+    <string name="label_data_usage_reset_date_change">Dữ liệu sử dụng sẽ được đặt lại vào %1$s của mỗi tháng</string>
     <string name="day">ngày</string>
     <string name="disable_battery_optimisation">Tắt tối ưu hóa pin</string>
     <string name="title_data_warning_notification">Cảnh báo dữ liệu sử dụng</string>
@@ -123,7 +123,7 @@
     <string name="avg_latency">Độ trễ trung bình</string>
     <string name="louis_leblanc_summary">Pháp</string>
     <string name="network_speed_title">Tốc độ mạng: %1$s</string>
-    <string name="label_reset_every_month">%1$s%2$s mỗi tháng</string>
+    <string name="label_reset_every_month">%1$s mỗi tháng</string>
     <string name="system_data_usage">Dữ liệu sử dụng của hệ thông</string>
     <string name="network_speed_upload">Tải lên: %1$s</string>
     <string name="network_speed_download">Tải xuống: %1$s</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -59,7 +59,6 @@
     <string name="MarongHappy_summary">Hàn</string>
     <string name="label_crash_logs_copied">Đã sao chép nhật ký sự cố vào khay nhớ tạm</string>
     <string name="app_contributors">Người đóng góp ứng dụng</string>
-    <string name="label_plan_details_title">gói %1$s đã kích hoạt</string>
     <string name="tadekdudek">tadekdudek</string>
     <string name="home_plan_usage_details">%1$s đã dùng | %2$s</string>
     <string name="label_current_plan">Gói hiện tại</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -136,7 +136,7 @@
     <string name="label_widget_refresh_interval_change">微件将每 %1$s 更新</string>
     <string name="label_notification_refresh_interval_change">通知将每 %1$s 更新</string>
     <string name="label_data_usage_reset_time_change">数据用量将在每 %1$s %2$s 重置</string>
-    <string name="label_data_usage_reset_date_change">数据用量将在每月的 %1$d%2$s 重置</string>
+    <string name="label_data_usage_reset_date_change">数据用量将在每月的 %1$s 重置</string>
     <string name="remaining_data_info_enabled">剩余流量信息已启用</string>
     <string name="remaining_data_info_disabled">剩余流量信息已禁用</string>
     <string name="label_monitoring_no_plan">添加一个流量使用计划以继续</string>
@@ -208,7 +208,7 @@
     <string name="label_want_to_contribute_language">未找到您的语言？点此了解如何帮助我们.</string>
     <string name="current_language">当前语言</string>
     <string name="available_languages">可用语言</string>
-    <string name="label_reset_every_month">每月 %1$s%2$s</string>
+    <string name="label_reset_every_month">每月 %1$s</string>
     <string name="setup_usage_reset_date">用量重置日期</string>
     <string name="system_data_usage">系统数据用量</string>
     <string name="cracky5322_summary">繁体中文 译者</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -140,7 +140,7 @@
     <string name="label_widget_refresh_interval_change">小工具將每 %1$s 更新</string>
     <string name="label_notification_refresh_interval_change">通知將每 %1$s 更新</string>
     <string name="label_data_usage_reset_time_change">在每 %1$s %2$s 將會重設數據使用量</string>
-    <string name="label_data_usage_reset_date_change">數據使用量會在每個月 %1$d%2$s 被重設</string>
+    <string name="label_data_usage_reset_date_change">數據使用量會在每個月 %1s 被重設</string>
     <string name="remaining_data_info_enabled">剩餘流量資訊已啟用</string>
     <string name="remaining_data_info_disabled">剩餘流量資訊已停用</string>
     <string name="label_monitoring_no_plan">新增一個流量使用計劃以繼續</string>
@@ -216,7 +216,7 @@
     <string name="label_want_to_contribute_language">未找到您的語言？點此瞭解如何幫助我們！</string>
     <string name="current_language">當前語言</string>
     <string name="available_languages">可用語言</string>
-    <string name="label_reset_every_month">每個月 %1$s%2$s</string>
+    <string name="label_reset_every_month">每個月 %1$s</string>
     <string name="setup_usage_reset_date">數據流量重設日期</string>
     <string name="system_data_usage">系統數據使用</string>
     <string name="cracky5322_summary">繁體中文</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -387,7 +387,6 @@
     <string name="label_filter_app_usage">過濾應用程式使用情況</string>
     <string name="label_filter">過濾</string>
     <string name="label_current_plan">目前方案</string>
-    <string name="label_plan_details_title">%1$s 活躍方案</string>
     <string name="home_plan_usage_details">%1$s 已用 | %2$s</string>
     <string name="label_plan_validity">有效期至 %1$s | %2$s</string>
     <string name="always_show_total">總是顯示總額</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -144,7 +144,7 @@
     <string name="label_widget_refresh_interval_change">Widget will be updated every %1$s</string>
     <string name="label_notification_refresh_interval_change">Notification will be updated every %1$s</string>
     <string name="label_data_usage_reset_time_change">Reset data usage every %1$s at %2$s</string>
-    <string name="label_data_usage_reset_date_change">Data usage will be reset on %1$d%2$s of every month</string>
+    <string name="label_data_usage_reset_date_change">Data usage will be reset on %1$s of every month</string>
     <string name="remaining_data_info_enabled">Remaining data info enabled</string>
     <string name="remaining_data_info_disabled">Remaining data info disabled</string>
     <string name="label_monitoring_no_plan">Add a data plan to start monitoring</string>
@@ -222,7 +222,7 @@
     <string name="label_want_to_contribute_language">Click here to help translate the app into your language.</string>
     <string name="current_language">Current</string>
     <string name="available_languages">Available</string>
-    <string name="label_reset_every_month">%1$s%2$s of every month</string>
+    <string name="label_reset_every_month">%1$s of every month</string>
     <string name="setup_usage_reset_date">Data usage reset date</string>
     <string name="system_data_usage">System data usage</string>
     <string name="cracky5322_summary">Traditional Chinese</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -434,7 +434,6 @@
     <string name="label_filter_app_usage">Filter App Usage</string>
     <string name="label_filter">Filter</string>
     <string name="label_current_plan">Current Plan</string>
-    <string name="label_plan_details_title">%1$s plan active</string>
     <string name="home_plan_usage_details">%1$s used | %2$s</string>
     <string name="label_plan_validity">Valid till %1$s | %2$s</string>
     <string name="always_show_total">Always show total</string>
@@ -516,4 +515,8 @@
     <string name="xxx_summary">Russian</string>
     <string name="ofermar">ofermar</string>
     <string name="ofermar_summary">Hebrew</string>
+    <string name="label_plan_details_title_unknown">Unknown plan active</string>
+    <string name="label_plan_details_title_monthly">Monthly plan active</string>
+    <string name="label_plan_details_title_daily">Daily plan active</string>
+    <string name="label_plan_details_title_custom">Custom plan active</string>
 </resources>


### PR DESCRIPTION
The whole handling of localised date and time strings in the code would probably merit a more thorough once over, but these commits fix at least the most glaring things I've immediately noticed.

Namely mainly
- re-using the strings for 'Weekly', 'Monthly' and 'Custom' from the settings panel for the text in the home activity produces ungrammatical results in some languages
- the validity text always uses English number ordinals (1st, 2nd and so on), plus month names based on the device language instead of the app language